### PR TITLE
fix: removed unnecessary env var (#67)

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -5,7 +5,7 @@ if not (vim.uv or vim.loop).fs_stat(lazypath) then
   -- stylua: ignore
   vim.fn.system({ "git", "clone", "--filter=blob:none", "https://github.com/folke/lazy.nvim.git", "--branch=stable", lazypath })
 end
-vim.opt.rtp:prepend(vim.env.LAZY or lazypath)
+vim.opt.rtp:prepend(lazypath)
 
 require("lazy").setup({
   spec = {


### PR DESCRIPTION
according to https://github.com/LazyVim/LazyVim/issues/2063#issuecomment-2143841592 this is not needed